### PR TITLE
The old elementsWrites implementation prevented publishing for 2.13. …

### DIFF
--- a/src/main/scala/com/traveltime/slack/dto/Button.scala
+++ b/src/main/scala/com/traveltime/slack/dto/Button.scala
@@ -2,6 +2,8 @@ package com.traveltime.slack.dto
 
 import com.traveltime.slack.dto.Button.{ActionId, ButtonStyle}
 import com.traveltime.slack.dto.InteractiveMessage.Element
+import com.traveltime.slack.json.InteractiveMessageWrites.{confirmDialogWrites, textObjectWrites}
+import play.api.libs.json.{JsObject, JsString}
 
 /**
  * [[https://api.slack.com/reference/block-kit/block-elements#button]]
@@ -13,7 +15,19 @@ case class Button(
   url: Option[String] = None,
   value: Option[String] = None,
   confirm: Option[ConfirmDialog] = None
-) extends Element
+) extends Element {
+  override def asJson = JsObject(
+    Map(
+      "type"      -> Some(JsString("button")),
+      "text"      -> Some(textObjectWrites.writes(textObject)),
+      "action_id" -> Some(JsString(actionId.id)),
+      "url"       -> url.map(JsString),
+      "value"     -> value.map(JsString),
+      "style"     -> style.map(style => JsString(style.literal)),
+      "confirm"   -> confirm.map(confirmDialogWrites.writes)
+    ).collect { case (key, Some(value)) => (key, value) }
+  )
+}
 
 object Button {
   case class ActionId(id: String)

--- a/src/main/scala/com/traveltime/slack/dto/InteractiveMessage.scala
+++ b/src/main/scala/com/traveltime/slack/dto/InteractiveMessage.scala
@@ -1,6 +1,7 @@
 package com.traveltime.slack.dto
 
 import com.traveltime.slack.dto.InteractiveMessage.{Block, Channel}
+import play.api.libs.json.JsValue
 
 case class InteractiveMessage(channel: Channel, blocks: Vector[Block])
 
@@ -10,7 +11,9 @@ object InteractiveMessage {
    */
   case class Channel(id: String)
 
-  trait Element
+  trait Element {
+    def asJson: JsValue
+  }
 
   sealed abstract class Block(val blockType: String)
   case object Divider extends Block("divider")

--- a/src/main/scala/com/traveltime/slack/json/InteractiveMessageWrites.scala
+++ b/src/main/scala/com/traveltime/slack/json/InteractiveMessageWrites.scala
@@ -1,7 +1,7 @@
 package com.traveltime.slack.json
 import com.traveltime.slack.dto.InteractiveMessage._
 import com.traveltime.slack.dto.TextObject.{Mrkdwn, PlainText, TextType}
-import com.traveltime.slack.dto.{Button, ConfirmDialog, InteractiveMessage, TextObject}
+import com.traveltime.slack.dto.{ConfirmDialog, InteractiveMessage, TextObject}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -37,25 +37,9 @@ object InteractiveMessageWrites {
     (__ \ "deny").write[TextObject]
   )(unlift(ConfirmDialog.unapply))
 
-  val buttonWrites: Writes[Button] = (button: Button) => JsObject(
-    Map(
-      "type" -> Some(JsString("button")),
-      "text" -> Some(textObjectWrites.writes(button.textObject)),
-      "action_id" -> Some(JsString(button.actionId.id)),
-      "url" -> button.url.map(JsString),
-      "value" -> button.value.map(JsString),
-      "style" -> button.style.map(style => JsString(style.literal)),
-      "confirm" -> button.confirm.map(confirmDialogWrites.writes)
-    ).collect{ case (key, Some(value)) => (key, value) }
-  )
-
-  val elementsWrites: Writes[Element] = Writes[Element] {
-    case e: Button => buttonWrites.writes(e)
-  }
-
   val actionsWrites: Writes[Actions] = (actions: Actions) => JsObject(Map(
     "type" -> JsString(actions.blockType),
-    "elements" -> JsArray(actions.elements.map(elementsWrites.writes))
+    "elements" -> JsArray(actions.elements.map(_.asJson))
   ))
 
   val dividerWrites: Writes[Divider.type] = (_: InteractiveMessage.Divider.type) =>


### PR DESCRIPTION
…Element is not a sealed trait, so 2.13 compilation would fail.

To fix this and to allow library users to implement their own Slack Actions elements, json representation of an Element was moved inside the Element trait.