### PR TITLE
User-defined Element types and writes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 name := "scala-slack-client"
 
+crossScalaVersions := Seq("2.13.6", "2.12.14")
+
 scalacOptions ++= Seq(
   "-feature",
   "-deprecation",

--- a/src/main/scala/com/traveltime/slack/ApiSlackClient.scala
+++ b/src/main/scala/com/traveltime/slack/ApiSlackClient.scala
@@ -3,6 +3,7 @@ package com.traveltime.slack
 import com.traveltime.slack.HooksSlackClient.Error
 import com.traveltime.slack.dto.{InteractiveMessage, SlackFile}
 import com.traveltime.slack.dto.InteractiveMessage.Channel
+import play.api.libs.json.Writes
 
 import scala.concurrent.Future
 
@@ -12,5 +13,5 @@ trait ApiSlackClient {
   val multipartFormDataContentType = "multipart/form-data"
 
   def uploadFile(channels: Seq[Channel], authToken: String, slackFile: SlackFile): Future[Either[Error, Unit]]
-  def sendInteractiveMessage(interactiveMessage: InteractiveMessage, authToken: String): Future[Either[Error, Unit]]
+  def sendInteractiveMessage[A : Writes](interactiveMessage: InteractiveMessage[A], authToken: String): Future[Either[Error, Unit]]
 }

--- a/src/main/scala/com/traveltime/slack/SlackHttpClient.scala
+++ b/src/main/scala/com/traveltime/slack/SlackHttpClient.scala
@@ -1,7 +1,6 @@
 package com.traveltime.slack
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.traveltime.slack.HooksSlackClient.{Error, HookMessage}
 import com.traveltime.slack.dto.InteractiveMessage.Channel
 import com.traveltime.slack.dto.{InteractiveMessage, SlackFile}
@@ -10,7 +9,7 @@ import com.traveltime.slack.util.PayloadMapper
 import com.traveltime.slack.util.RequestHelpers._
 import dispatch.{url => Url}
 import org.asynchttpclient.request.body.multipart.{FilePart, StringPart}
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsValue, Json, Writes}
 
 import scala.concurrent.Future
 
@@ -23,7 +22,7 @@ object SlackHttpClient extends HooksSlackClient with ApiSlackClient {
     sendPost(url, body, Map.empty)
   }
 
-  def sendInteractiveMessage(interactiveMessage: InteractiveMessage, authToken: String): Future[Either[Error, Unit]] =
+  def sendInteractiveMessage[A : Writes](interactiveMessage: InteractiveMessage[A], authToken: String): Future[Either[Error, Unit]] =
     sendPost(
       postMessageUrl,
       Json.toJson(interactiveMessage),

--- a/src/main/scala/com/traveltime/slack/dto/Button.scala
+++ b/src/main/scala/com/traveltime/slack/dto/Button.scala
@@ -1,7 +1,6 @@
 package com.traveltime.slack.dto
 
 import com.traveltime.slack.dto.Button.{ActionId, ButtonStyle}
-import com.traveltime.slack.dto.InteractiveMessage.Element
 
 /**
  * [[https://api.slack.com/reference/block-kit/block-elements#button]]
@@ -13,7 +12,7 @@ case class Button(
   url: Option[String] = None,
   value: Option[String] = None,
   confirm: Option[ConfirmDialog] = None
-) extends Element
+)
 
 object Button {
   case class ActionId(id: String)

--- a/src/main/scala/com/traveltime/slack/dto/InteractiveMessage.scala
+++ b/src/main/scala/com/traveltime/slack/dto/InteractiveMessage.scala
@@ -10,8 +10,8 @@ object InteractiveMessage {
    */
   case class Channel(id: String)
 
-  sealed abstract class Block[A](val blockType: String)
-  case class Divider[A]() extends Block[A]("divider")
-  case class Section[A](textObject: TextObject) extends Block[A]("section")
+  sealed abstract class Block[+A](val blockType: String)
+  case object Divider extends Block[Nothing]("divider")
+  case class Section(textObject: TextObject) extends Block[Nothing]("section")
   case class Actions[A](elements: Vector[A]) extends Block[A]("actions")
 }

--- a/src/main/scala/com/traveltime/slack/dto/InteractiveMessage.scala
+++ b/src/main/scala/com/traveltime/slack/dto/InteractiveMessage.scala
@@ -2,7 +2,7 @@ package com.traveltime.slack.dto
 
 import com.traveltime.slack.dto.InteractiveMessage.{Block, Channel}
 
-case class InteractiveMessage(channel: Channel, blocks: Vector[Block])
+case class InteractiveMessage[A](channel: Channel, blocks: Vector[Block[A]])
 
 object InteractiveMessage {
   /**
@@ -10,10 +10,8 @@ object InteractiveMessage {
    */
   case class Channel(id: String)
 
-  trait Element
-
-  sealed abstract class Block(val blockType: String)
-  case object Divider extends Block("divider")
-  case class Section(textObject: TextObject) extends Block("section")
-  case class Actions(elements: Vector[Element]) extends Block("actions")
+  sealed abstract class Block[A](val blockType: String)
+  case class Divider[A]() extends Block[A]("divider")
+  case class Section[A](textObject: TextObject) extends Block[A]("section")
+  case class Actions[A](elements: Vector[A]) extends Block[A]("actions")
 }

--- a/src/main/scala/com/traveltime/slack/json/InteractiveMessageWrites.scala
+++ b/src/main/scala/com/traveltime/slack/json/InteractiveMessageWrites.scala
@@ -1,4 +1,5 @@
 package com.traveltime.slack.json
+
 import com.traveltime.slack.dto.InteractiveMessage._
 import com.traveltime.slack.dto.TextObject.{Mrkdwn, PlainText, TextType}
 import com.traveltime.slack.dto.{Button, ConfirmDialog, InteractiveMessage, TextObject}
@@ -25,7 +26,7 @@ object InteractiveMessageWrites {
   implicit val textObjectWrites: Writes[TextObject] = (textObject: TextObject) =>
     textTypeWrites(textObject.textType) ++ JsObject(Map("text" -> JsString(textObject.text)))
 
-  val sectionWrites: Writes[Section] = (section: Section) => JsObject(Map(
+  def sectionWrites[A]: Writes[Section[A]] = (section: Section[A]) => JsObject(Map(
     "type" -> JsString(section.blockType),
     "text" -> textObjectWrites.writes(section.textObject)
   ))
@@ -37,7 +38,7 @@ object InteractiveMessageWrites {
     (__ \ "deny").write[TextObject]
   )(unlift(ConfirmDialog.unapply))
 
-  val buttonWrites: Writes[Button] = (button: Button) => JsObject(
+  implicit val buttonWrites: Writes[Button] = (button: Button) => JsObject(
     Map(
       "type" -> Some(JsString("button")),
       "text" -> Some(textObjectWrites.writes(button.textObject)),
@@ -46,29 +47,31 @@ object InteractiveMessageWrites {
       "value" -> button.value.map(JsString),
       "style" -> button.style.map(style => JsString(style.literal)),
       "confirm" -> button.confirm.map(confirmDialogWrites.writes)
-    ).collect{ case (key, Some(value)) => (key, value) }
+    ).collect { case (key, Some(value)) => (key, value) }
   )
 
-  val elementsWrites: Writes[Element] = Writes[Element] {
-    case e: Button => buttonWrites.writes(e)
+  def actionsWrites[A: Writes]: Writes[Actions[A]] = (actions: Actions[A]) => {
+    val w = implicitly[Writes[A]]
+    JsObject(Map(
+      "type" -> JsString(actions.blockType),
+      "elements" -> JsArray(actions.elements.map(w.writes))
+    ))
   }
 
-  val actionsWrites: Writes[Actions] = (actions: Actions) => JsObject(Map(
-    "type" -> JsString(actions.blockType),
-    "elements" -> JsArray(actions.elements.map(elementsWrites.writes))
-  ))
-
-  val dividerWrites: Writes[Divider.type] = (_: InteractiveMessage.Divider.type) =>
+  def dividerWrites[A]: Writes[Divider[A]] = _ =>
     JsObject(Map("type" -> JsString("divider")))
 
-  implicit val blockWrites: Writes[Block] = Writes[Block] {
-    case b: Divider.type => dividerWrites.writes(b)
-    case b: Section => sectionWrites.writes(b)
-    case b: Actions => actionsWrites.writes(b)
+  implicit def blockWrites[A: Writes]: Writes[Block[A]] = Writes[Block[A]] {
+    case b: Divider[A] => dividerWrites.writes(b)
+    case b: Section[A] => sectionWrites.writes(b)
+    case b: Actions[A] =>
+      val w = implicitly[Writes[A]]
+      actionsWrites(w).writes(b)
   }
 
-  implicit val interactiveMessageWrites: Writes[InteractiveMessage] = (
-    (__ \ "channel").write[String].contramap[Channel](_.id) and
-    (__ \ "blocks").write[Vector[Block]]
-  )(unlift(InteractiveMessage.unapply))
+  implicit def interactiveMessageWrites[A: Writes]: Writes[InteractiveMessage[A]] =
+    (
+      (__ \ "channel").write[String].contramap[Channel](_.id) and
+        (__ \ "blocks").write[Vector[Block[A]]]
+      ) (unlift(InteractiveMessage.unapply[A]))
 }

--- a/src/main/scala/com/traveltime/slack/json/InteractiveMessageWrites.scala
+++ b/src/main/scala/com/traveltime/slack/json/InteractiveMessageWrites.scala
@@ -26,7 +26,7 @@ object InteractiveMessageWrites {
   implicit val textObjectWrites: Writes[TextObject] = (textObject: TextObject) =>
     textTypeWrites(textObject.textType) ++ JsObject(Map("text" -> JsString(textObject.text)))
 
-  def sectionWrites[A]: Writes[Section[A]] = (section: Section[A]) => JsObject(Map(
+  val sectionWrites: Writes[Section] = (section: Section) => JsObject(Map(
     "type" -> JsString(section.blockType),
     "text" -> textObjectWrites.writes(section.textObject)
   ))
@@ -58,12 +58,12 @@ object InteractiveMessageWrites {
     ))
   }
 
-  def dividerWrites[A]: Writes[Divider[A]] = _ =>
+  val dividerWrites: Writes[Divider.type] = (_: Divider.type) =>
     JsObject(Map("type" -> JsString("divider")))
 
   implicit def blockWrites[A: Writes]: Writes[Block[A]] = Writes[Block[A]] {
-    case b: Divider[A] => dividerWrites.writes(b)
-    case b: Section[A] => sectionWrites.writes(b)
+    case b: Divider.type => dividerWrites.writes(b)
+    case b: Section => sectionWrites.writes(b)
     case b: Actions[A] =>
       val w = implicitly[Writes[A]]
       actionsWrites(w).writes(b)

--- a/src/test/scala/com/traveltime/slack/json/InteractiveMessageWritesSpec.scala
+++ b/src/test/scala/com/traveltime/slack/json/InteractiveMessageWritesSpec.scala
@@ -2,7 +2,7 @@ package com.traveltime.slack.json
 
 import com.traveltime.slack.dto.Button.{ActionId, Danger, Primary}
 import com.traveltime.slack.dto.{Button, InteractiveMessage, TextObject}
-import com.traveltime.slack.dto.InteractiveMessage.{Actions, Block, Channel, Divider, Section}
+import com.traveltime.slack.dto.InteractiveMessage.{Actions, Channel, Divider, Section}
 import com.traveltime.slack.dto.TextObject.{Mrkdwn, PlainText}
 import org.scalatest.{FunSpec, Matchers}
 import play.api.libs.json.Json
@@ -16,9 +16,9 @@ class InteractiveMessageWritesSpec extends FunSpec with Matchers {
 
     it("should serialize interactive slack message") {
 
-      val section = Section[Button](TextObject(Mrkdwn(), "Hello, I would like to do some things"))
-      val divider = Divider[Button]()
-      val section2 = Section[Button](TextObject(PlainText(), "Can I do this?"))
+      val section = Section(TextObject(Mrkdwn(), "Hello, I would like to do some things"))
+      val divider = Divider
+      val section2 = Section(TextObject(PlainText(), "Can I do this?"))
       val approveButton = Button(
         textObject = TextObject(PlainText(true), "Approve"),
         actionId = ActionId("approve_for_123"),
@@ -35,7 +35,7 @@ class InteractiveMessageWritesSpec extends FunSpec with Matchers {
       )
       val actions = Actions(Vector(approveButton, denyButton))
 
-      val blocks: Vector[Block[Button]] = Vector(section, divider, section2, actions)
+      val blocks = Vector(section, divider, section2, actions)
       val interactiveSlackMessage = InteractiveMessage(Channel("test_channel_Id"), blocks)
 
       val source = Source.fromURL(getClass.getClassLoader.getResource("json/interactiveMessage.json"))

--- a/src/test/scala/com/traveltime/slack/json/InteractiveMessageWritesSpec.scala
+++ b/src/test/scala/com/traveltime/slack/json/InteractiveMessageWritesSpec.scala
@@ -2,7 +2,7 @@ package com.traveltime.slack.json
 
 import com.traveltime.slack.dto.Button.{ActionId, Danger, Primary}
 import com.traveltime.slack.dto.{Button, InteractiveMessage, TextObject}
-import com.traveltime.slack.dto.InteractiveMessage.{Actions, Channel, Divider, Section}
+import com.traveltime.slack.dto.InteractiveMessage.{Actions, Block, Channel, Divider, Section}
 import com.traveltime.slack.dto.TextObject.{Mrkdwn, PlainText}
 import org.scalatest.{FunSpec, Matchers}
 import play.api.libs.json.Json
@@ -16,9 +16,9 @@ class InteractiveMessageWritesSpec extends FunSpec with Matchers {
 
     it("should serialize interactive slack message") {
 
-      val section = Section(TextObject(Mrkdwn(), "Hello, I would like to do some things"))
-      val divider = Divider
-      val section2 = Section(TextObject(PlainText(), "Can I do this?"))
+      val section = Section[Button](TextObject(Mrkdwn(), "Hello, I would like to do some things"))
+      val divider = Divider[Button]()
+      val section2 = Section[Button](TextObject(PlainText(), "Can I do this?"))
       val approveButton = Button(
         textObject = TextObject(PlainText(true), "Approve"),
         actionId = ActionId("approve_for_123"),
@@ -35,7 +35,7 @@ class InteractiveMessageWritesSpec extends FunSpec with Matchers {
       )
       val actions = Actions(Vector(approveButton, denyButton))
 
-      val blocks = Vector(section, divider, section2, actions)
+      val blocks: Vector[Block[Button]] = Vector(section, divider, section2, actions)
       val interactiveSlackMessage = InteractiveMessage(Channel("test_channel_Id"), blocks)
 
       val source = Source.fromURL(getClass.getClassLoader.getResource("json/interactiveMessage.json"))


### PR DESCRIPTION
Removed the Elements trait in favor of a generic Actions[A].

The user can define their own type to use as the elements in InteractiveMessage. This requires the type to have a json Writes instance.